### PR TITLE
fix: resolve error due to actions/download-artifact: v3 deprecation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,14 +16,14 @@ jobs:
       pages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: hydephp/action@master
         with:
           debug: true
           upload-artifact: true
           deploy-to: "pages"
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build
           path: build


### PR DESCRIPTION
This should resolve the error of the integration tests due to the use of the actions/download-artifact v3 which is deprecated. It also updates the checkout action to v4.

Reference: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

This PR proposes the same changes as in https://github.com/hyde-staging/github-action-test-project-1/pull/1 